### PR TITLE
feat: add Lucid Emulator ledger mutations

### DIFF
--- a/src/transactions/helpers/lucid.ts
+++ b/src/transactions/helpers/lucid.ts
@@ -1,5 +1,3 @@
-import assert from "assert";
-
 import {
   Address,
   Emulator,
@@ -9,6 +7,7 @@ import {
 } from "lucid-cardano";
 
 import { Hex, UnixTime } from "@/types";
+import { assert } from "@/utils";
 
 export function getCurrentTime(lucid: Lucid): UnixTime {
   return lucid.provider instanceof Emulator ? lucid.provider.now() : Date.now();


### PR DESCRIPTION
To allow testing transactions without all the bootstrapping processes. Instead of sending multiple "pre-conditions" transactions just to reach the point of testing, we can just assume that certain UTxOs exist and build transactions based on those UTxOs.