### PR TITLE
feat: simplify schema for ByteArray

### DIFF
--- a/src/commands/compile-scripts.ts
+++ b/src/commands/compile-scripts.ts
@@ -16,6 +16,9 @@ import getDedicatedTreasuryV from "@/contracts/treasury/dedicated-treasury.v/mai
 import getOpenTreasuryV from "@/contracts/treasury/open-treasury.v/main";
 import getSharedTreasuryV from "@/contracts/treasury/shared-treasury.v/main";
 
+// TODO: @sk-saru, @sk-umiuma: Use Hex for all those script hash params,
+// both this file and the contracts.
+
 export function compileProtocolNftScript(seedUtxo: UTxO): UplcProgram {
   return compile(
     getProtocolNft(seedUtxo.txHash, seedUtxo.outputIndex.toString())

--- a/src/contracts/compile.ts
+++ b/src/contracts/compile.ts
@@ -2,7 +2,7 @@ import { UplcProgram, bytesToHex } from "@hyperionbt/helios";
 import { Data, Script } from "lucid-cardano";
 
 import { toJson } from "@/schema";
-import { CborHex } from "@/types";
+import { Hex } from "@/types";
 
 import modBackingVTypes from "./backing/backing.v/types";
 import modProofOfBackingMpTypes from "./backing/proof-of-backing.mp/types";
@@ -69,6 +69,6 @@ export function exportScript(uplcProgram: UplcProgram): Script {
   };
 }
 
-export function serialize(uplcProgram: UplcProgram): CborHex {
+export function serialize(uplcProgram: UplcProgram): Hex {
   return bytesToHex(uplcProgram.toCbor());
 }

--- a/src/schema/uplc.ts
+++ b/src/schema/uplc.ts
@@ -9,28 +9,29 @@ import {
   TNever,
   TProperties,
   TSchema,
-  TString,
-  TUint8Array,
   Type,
   type Static,
 } from "@sinclair/typebox";
 import { Custom } from "@sinclair/typebox/custom";
 import { Data } from "lucid-cardano";
 
+import { isData } from "@/types";
+
 // Re-exports
 export { type Static };
 
 // Custom typebox
-Custom.Set("BigInt", (_, value) => typeof value === "bigint");
+Custom.Set("Int", (_, value) => typeof value === "bigint");
+Custom.Set("Data", (_, value) => isData(value));
 Custom.Set("Map", (_, value) => value instanceof Map);
 Custom.Set("Option", () => true);
 
 // TODO: Restrict to TUplc instead of TSchema
 export type TUplc =
   | TInt
-  | TBoolean
+  | TBool
+  | TByteArray
   | TString
-  | TUint8Array
   | TRawData
   | TOption
   | TList
@@ -40,18 +41,25 @@ export type TUplc =
 
 // Primitives
 export interface TInt extends TSchema, NumericOptions {
-  [Kind]: "BigInt";
+  [Kind]: "Int";
   static: bigint;
   type: "bigint";
 }
 export const Int: TInt = {
   ...Type.Unsafe({}),
-  [Kind]: "BigInt",
+  [Kind]: "Int",
   type: "bigint",
 };
+
+export type TBool = TBoolean;
 export const Bool = Type.Boolean();
-export const String = Type.String();
-export const ByteArray = Type.Uint8Array();
+
+// Since Hex is just a type alias for string, it's not worth creating a new TSchema
+export type TByteArray = typeof ByteArray;
+export const ByteArray = Type.String({ format: "hex" });
+
+export type TString = typeof String;
+export const String = Type.String({ format: "text" });
 
 // Raw Data
 export type RawData = { data: Data };

--- a/src/transactions/helpers/constructors.ts
+++ b/src/transactions/helpers/constructors.ts
@@ -19,7 +19,7 @@ export function constructProjectIdUsingBlake2b({
   outputIndex,
 }: OutRef): Hex {
   const outputId: S.TxOutputId = {
-    txId: { $txId: fromHex(txHash) },
+    txId: { $txId: txHash },
     index: BigInt(outputIndex),
   };
   const cbor = S.toCbor(S.toData(outputId, S.TxOutputId));
@@ -27,7 +27,7 @@ export function constructProjectIdUsingBlake2b({
 }
 
 export function constructScriptHash(hash: Hex): S.ScriptHash {
-  return { scriptHash: { $hash: fromHex(hash) } };
+  return { scriptHash: { $hash: hash } };
 }
 
 export function constructAssetClass(
@@ -36,7 +36,7 @@ export function constructAssetClass(
 ): S.AssetClass {
   return {
     mintingPolicyHash: constructScriptHash(mintingPolicyHash),
-    tokenName: fromHex(tokenName),
+    tokenName: tokenName,
   };
 }
 
@@ -45,11 +45,7 @@ export function constructMigratableScript(
   migrations: Record<Hex, { mintingPolicyHash: Hex; tokenName: Hex }>
 ): MigratableScript {
   return {
-    latest: {
-      scriptHash: {
-        $hash: fromHex(latestScriptHash),
-      },
-    },
+    latest: { scriptHash: { $hash: latestScriptHash } },
     migrations: new Map(
       Object.entries(migrations).map(
         ([migratingScriptHash, { mintingPolicyHash, tokenName }]) => [
@@ -69,11 +65,11 @@ export function constructAddress(address: Address): S.Address {
     paymentCredential.type === "Key"
       ? {
           paymentType: "PubKey",
-          $: { pubKeyHash: { $hash: fromHex(paymentCredential.hash) } },
+          $: { pubKeyHash: { $hash: paymentCredential.hash } },
         }
       : {
           paymentType: "Validator",
-          $: { scriptHash: { $hash: fromHex(paymentCredential.hash) } },
+          $: { scriptHash: { $hash: paymentCredential.hash } },
         };
 
   const conStakingCredential: S.StakingCredential | null = stakeCredential
@@ -81,11 +77,7 @@ export function constructAddress(address: Address): S.Address {
         stakingType: "Hash",
         $: {
           stakingHash: "Validator",
-          $: {
-            scriptHash: {
-              $hash: fromHex(stakeCredential.hash),
-            },
-          },
+          $: { scriptHash: { $hash: stakeCredential.hash } },
         },
       }
     : null;

--- a/src/transactions/project/create.ts
+++ b/src/transactions/project/create.ts
@@ -1,12 +1,4 @@
-import {
-  Address,
-  fromHex,
-  Lucid,
-  PolicyId,
-  Script,
-  Unit,
-  UTxO,
-} from "lucid-cardano";
+import { Address, Lucid, PolicyId, Script, Unit, UTxO } from "lucid-cardano";
 
 import { PROJECT_AT_TOKEN_NAMES } from "@/contracts/common/constants";
 import * as S from "@/schema";
@@ -84,12 +76,12 @@ export function createProjectTx(
     : null;
 
   const projectScriptDatum: ProjectScriptDatum = {
-    projectId: { id: fromHex(projectId) },
+    projectId: { id: projectId },
     stakingKeyDeposit: protocolParamsDatum.stakeKeyDeposit,
   };
 
   const projectDetailDatum: ProjectDetailDatum = {
-    projectId: { id: fromHex(projectId) },
+    projectId: { id: projectId },
     withdrawnFunds: 0n,
     sponsoredUntil: null,
     informationCid: informationCid,
@@ -97,7 +89,7 @@ export function createProjectTx(
   };
 
   const projectDatum: ProjectDatum = {
-    projectId: { id: fromHex(projectId) },
+    projectId: { id: projectId },
     ownerAddress: constructAddress(ownerAddress),
     milestoneReached: 0n,
     isStakingDelegationManagedByProtocol: true,
@@ -105,12 +97,12 @@ export function createProjectTx(
   };
 
   const dedicatedTreasuryDatum: DedicatedTreasuryDatum = {
-    projectId: { id: fromHex(projectId) },
+    projectId: { id: projectId },
     governorAda: protocolParamsDatum.governorShareRatio * minTotalFees,
     tag: {
       kind: "TagOriginated",
       seed: {
-        txId: { $txId: fromHex(seedUtxo.txHash) },
+        txId: { $txId: seedUtxo.txHash },
         index: BigInt(seedUtxo.outputIndex),
       },
     },
@@ -119,7 +111,7 @@ export function createProjectTx(
   const projectMintingRedeemer: ProjectMintingRedeemer = {
     case: "NewProject",
     projectSeed: {
-      txId: { $txId: fromHex(seedUtxo.txHash) },
+      txId: { $txId: seedUtxo.txHash },
       index: BigInt(seedUtxo.outputIndex),
     },
   };

--- a/src/transactions/protocol/apply.ts
+++ b/src/transactions/protocol/apply.ts
@@ -1,4 +1,4 @@
-import { Lucid, toHex, UTxO } from "lucid-cardano";
+import { Lucid, UTxO } from "lucid-cardano";
 
 import * as S from "@/schema";
 import {
@@ -46,9 +46,8 @@ export function applyProtocolProposalTx(
       "PubKey",
     "Governor address must have a public-key hash credential"
   );
-  const protocolGovernorPkh = toHex(
-    protocolParamsDatum.governorAddress.paymentCredential.$.pubKeyHash.$hash
-  );
+  const protocolGovernorPkh =
+    protocolParamsDatum.governorAddress.paymentCredential.$.pubKeyHash.$hash;
 
   return lucid
     .newTx()

--- a/src/transactions/protocol/cancel.ts
+++ b/src/transactions/protocol/cancel.ts
@@ -1,4 +1,4 @@
-import { Lucid, toHex, UTxO } from "lucid-cardano";
+import { Lucid, UTxO } from "lucid-cardano";
 
 import * as S from "@/schema";
 import {
@@ -33,9 +33,8 @@ export function cancelProtocolProposalTx(
       "PubKey",
     "Governor address must have a public-key hash credential"
   );
-  const protocolGovernorPkh = toHex(
-    protocolParamsDatum.governorAddress.paymentCredential.$.pubKeyHash.$hash
-  );
+  const protocolGovernorPkh =
+    protocolParamsDatum.governorAddress.paymentCredential.$.pubKeyHash.$hash;
 
   return lucid
     .newTx()

--- a/src/transactions/protocol/propose.ts
+++ b/src/transactions/protocol/propose.ts
@@ -1,4 +1,4 @@
-import { fromHex, Lucid, toHex, UTxO } from "lucid-cardano";
+import { Lucid, UTxO } from "lucid-cardano";
 
 import * as S from "@/schema";
 import {
@@ -40,9 +40,8 @@ export function proposeProtocolProposalTx(
       "PubKey",
     "Governor address must have a public-key hash credential"
   );
-  const protocolGovernorPkh = toHex(
-    protocolParamsDatum.governorAddress.paymentCredential.$.pubKeyHash.$hash
-  );
+  const protocolGovernorPkh =
+    protocolParamsDatum.governorAddress.paymentCredential.$.pubKeyHash.$hash;
 
   const txTimeEnd = getCurrentTime(lucid) + txTimePadding;
 
@@ -55,7 +54,7 @@ export function proposeProtocolProposalTx(
           1n,
       },
       base: {
-        txId: { $txId: fromHex(protocolParamsUtxo.txHash) },
+        txId: { $txId: protocolParamsUtxo.txHash },
         index: BigInt(protocolParamsUtxo.outputIndex),
       },
       params: proposedProtocolParamsDatum,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,25 @@
-export { type Data, type OutRef } from "lucid-cardano";
+// Note that the `string` case of Lucid `Data` is in hex form.
+import { Constr, type Data, type OutRef } from "lucid-cardano";
+
+export { type Data, type OutRef };
 
 export type Hex = string;
-export type CborHex = string;
 
 export type UnixTime = number;
 export type TimeDifference = number;
+
+// Guards
+export function isHex(value: unknown): value is Hex {
+  return typeof value === "string" && /^[0-9A-Fa-f]*$/.test(value);
+}
+
+export function isData(value: unknown): value is Data {
+  return (
+    typeof value === "bigint" ||
+    isHex(value) ||
+    (value instanceof Array && value.every(isData)) ||
+    (value instanceof Map &&
+      Array.from(value.entries()).every(([k, v]) => isData(k) && isData(v))) ||
+    value instanceof Constr
+  );
+}

--- a/tests/emulator.ts
+++ b/tests/emulator.ts
@@ -1,7 +1,7 @@
 import {
   Assets,
-  DatumHash,
   Datum,
+  DatumHash,
   Emulator,
   generateSeedPhrase,
   Lucid,
@@ -43,7 +43,7 @@ export function generateOutRef(): OutRef {
   // 32 bytes for txHash, 1 byte for outputIndex
   const bytes = crypto.getRandomValues(new Uint8Array(33));
   const txHash = toHex(bytes.slice(0, 32));
-  const outputIndex = bytes[33];
+  const outputIndex = bytes[32];
   return { txHash, outputIndex };
 }
 

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -1,8 +1,7 @@
 import * as helios from "@hyperionbt/helios";
-import { fromHex } from "lucid-cardano";
 
 import * as S from "@/schema";
-import { OutRef, Hex, CborHex } from "@/types";
+import { OutRef, Hex } from "@/types";
 
 describe("complex schema", () => {
   const OneStruct = S.Struct({
@@ -68,10 +67,10 @@ describe("complex schema", () => {
   function buildDatum({ a, b, c, d }: Params): Datum {
     return {
       direction: "Left",
-      foo: { a: fromHex(a) },
+      foo: { a },
       bar: { b: BigInt(b), c },
       baz: {
-        txId: { $txId: fromHex(d.txHash) },
+        txId: { $txId: d.txHash },
         index: BigInt(d.outputIndex),
       },
     };
@@ -91,7 +90,7 @@ describe("complex schema", () => {
   const datum: Datum = buildDatum(sampleParams);
 
   test("round trip", () => {
-    const sampleCbor: CborHex =
+    const sampleCbor =
       "d87b9f44beef1234d8799f9f182a4b48656c6c6f20576f726c64ffffd8799fd8799f5820e1ffe6d8e94556ce6f24e53d94dc5d9559c2cbc8f00dad3737c61cd0d60a91dcff0affff";
     const cbor = S.toCbor(S.toData(datum, Datum));
     expect(cbor).toBe(sampleCbor);


### PR DESCRIPTION
We used `Uint8Array` but it doesn't have a nice JSON serialization and also causes a lot of Hex string <-> `Uint8Array` conversion. So I decided to go back to Hex (a type alias of string) - which is less typesafe but acceptable since most contracts' types are `ByteArray`, and `String` is quite rare.